### PR TITLE
avdInsightsMonitoring - add condition for perf events

### DIFF
--- a/workload/bicep/modules/avdInsightsMonitoring/deploy.bicep
+++ b/workload/bicep/modules/avdInsightsMonitoring/deploy.bicep
@@ -100,7 +100,7 @@ module deployDiagnosticsAzurePolicyForAvd './.bicep/azureMonitoringPolicies.bice
 }
 
 // Performance counters
-module deployMonitoringEventsPerformanceSettings './.bicep/monitoringEventsPerformanceCounters.bicep' = {
+module deployMonitoringEventsPerformanceSettings './.bicep/monitoringEventsPerformanceCounters.bicep' = if (deployAlaWorkspace) {
   name: 'Events-Performance-${time}'
   params: {
       managementPlaneLocation: managementPlaneLocation


### PR DESCRIPTION
Added conditional for omitting deployment for Event and Perf counters if existing Log Analytics workspace option selected.  Conflict causes deployment failure per Issue #363.   Long-term likely need to have separate list of counters and events for existing LAW as there are some that aren't in the current variable.